### PR TITLE
Add configurable additional allowed directories for elisp-read-source-file

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,15 @@ The tool now checks ~package-user-dir~ and ~package-directory-list~ instead of
 hardcoding ~/elpa/~ paths. This improves compatibility with different Emacs
 configurations and package managers like Eask.
 
+** New features
+
+*** Configurable additional allowed directories for elisp-read-source-file
+Added ~elisp-dev-mcp-additional-allowed-dirs~ custom variable to allow users
+of alternative package managers (straight.el, elpaca, etc.) to configure
+additional directories that ~elisp-read-source-file~ can access. The feature
+maintains security through path normalization and validation while extending
+functionality for custom package setups.
+
 * elisp-dev-mcp 1.0.0 (2025-07-22)
 
 ** Initial release

--- a/README.org
+++ b/README.org
@@ -114,6 +114,23 @@ Before using the MCP server, you must start it in Emacs with =M-x mcp-server-lib
   - Works directly with paths from =elisp-get-function-definition=
   - Returns complete file contents as string
 
+** Configuration for Alternative Package Managers
+
+By default, =elisp-read-source-file= can only access Emacs system
+directories and standard =ELPA= packages. For users of alternative
+package managers like straight.el, elpaca, or custom package setups,
+you can configure additional allowed directories:
+
+#+begin_src elisp
+(setq elisp-dev-mcp-additional-allowed-dirs
+      '("~/.emacs.d/straight/build/"
+        "~/.emacs.d/straight/repos/"
+        "~/my-elisp-packages/"))
+#+end_src
+
+*Security Note:* Only add directories you trust, as this allows the
+ MCP server to read any =.el= files in these locations.
+
 * License
 
 This project is licensed under the GNU General Public License v3.0 (GPLv3) - see the LICENSE file for details.

--- a/elisp-dev-mcp.el
+++ b/elisp-dev-mcp.el
@@ -31,6 +31,7 @@
 (require 'help-fns)
 (require 'pp)
 (require 'info-look)
+(require 'cl-lib)
 
 
 ;;; System Directory Setup
@@ -46,6 +47,31 @@ Computed once at package load time from `data-directory'.")
 
 (defconst elisp-dev-mcp--server-id "elisp-dev-mcp"
   "Server ID for this MCP server.")
+
+(defgroup elisp-dev-mcp nil
+  "MCP server for agentic Elisp development."
+  :group 'tools
+  :prefix "elisp-dev-mcp-")
+
+(defcustom elisp-dev-mcp-additional-allowed-dirs nil
+  "Additional directories to allow for elisp-read-source-file.
+List of directory paths that should be accessible in addition to
+the default Emacs system and ELPA directories.
+
+This is useful for users of alternative package managers like
+straight.el, elpaca, or custom package setups.
+
+Example:
+  (setq elisp-dev-mcp-additional-allowed-dirs
+        \\='(\"~/.emacs.d/straight/build/\"
+           \"~/.emacs.d/straight/repos/\"
+           \"~/my-elisp-packages/\"))
+
+Security note: Only add directories you trust, as this allows
+the MCP server to read any .el files in these locations."
+  :type '(repeat directory)
+  :group 'elisp-dev-mcp
+  :safe (lambda (val) (and (listp val) (cl-every #'stringp val))))
 
 ;;; Utility Functions
 
@@ -620,7 +646,11 @@ MCP Parameters:
             (mapcar #'file-truename package-directory-list)
             ;; System lisp directory
             (when elisp-dev-mcp--system-lisp-dir
-              (list (file-truename elisp-dev-mcp--system-lisp-dir)))))
+              (list (file-truename elisp-dev-mcp--system-lisp-dir)))
+            ;; User-configured additional directories
+            (mapcar (lambda (dir)
+                      (file-truename (file-name-as-directory dir)))
+                    elisp-dev-mcp-additional-allowed-dirs)))
           ;; Check if file is under any allowed directory
           (allowed-p
            (cl-some


### PR DESCRIPTION
Fixes #2

## Summary

Adds support for configuring additional directories that
`elisp-read-source-file` can access, enabling users of alternative
package managers like straight.el or elpaca to readsource files from
their package directories.

## Changes

- **New custom variable**: `elisp-dev-mcp-additional-allowed-dirs` -
  list of additional accessible directories
- **Security**: Uses `file-truename` for path validation, maintains
  existing security model
- **Backward compatible**: Default behavior unchanged (secure by
  default)

## Usage

```elisp
(setq elisp-dev-mcp-additional-allowed-dirs
'("~/.emacs.d/straight/build/"
  "~/.emacs.d/straight/repos/"))
```

## Testing

Added 6 comprehensive tests covering functionality, security, and edge cases. All 67
tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a customizable setting to allow additional directories for reading source files, with path normalization and preserved default behavior; system paths remain protected.

* **Tests**
  * Added comprehensive tests covering defaults, customization, multiple directories, normalization, and security boundary behaviors.

* **Documentation**
  * Updated README and release notes with configuration guidance and a security note about trusting additional directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->